### PR TITLE
Integrate Algolia search indexing

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,6 @@
 = LiquiDoc
+:toc: preamble
+
 // tag::overview[]
 LiquiDoc is a documentation build utility for true single-sourcing of technical content and data.
 It is especially suited for documentation projects with various required output formats, but it is intended for any project with complex, versioned input data for use in docs, user interfaces, and even back-end code.
@@ -877,14 +879,56 @@ See <<per-build-properties-files>>.
 
 === Deploy Operations
 
-It's not clear how deeply we will delve into deploy operations, since other build systems (such as rake) would seem far more suitable.
-For testing purposes, however, spinning up a local webserver with the same stroke that you build a site is pretty rewarding and time saving.
+Mainstream deployment platforms are probebly better suited to tying all your operations together, but we plan to bake a few common operations in to help you get started.
+For true build-and-deployment control, consider build tools such as Make, Rake, and Gradle, or deployment tools like Travis CI, CircleCI, and Jenkins.
+
+==== Jekyll Serve
+
+For testing purposes, however, spinning up a local webserver with the same stroke that you build a site is pretty rewarding and time saving, so we'll start there.
 
 For now, this functionality is limited to adding a `--deploy` flag to your `liquidoc` command.
 This will attempt to serve files from the *destination* set for the associated Jekyll build.
 
 [WARNING]
 Deployment of Jekyll sites is both limited and untested under nonstandard conditions.
+
+==== Algolia Search Indexing for Jekyll
+
+If you're using Jekyll to build sites, LiquiDoc makes indexing your files with the Algolia cloud search service a matter of configuration.
+The heavy lifting is performed by the jekyll-algolia plugin, but LiquiDoc can handle indexing even a complex site by using the same configuration that built your HTML content (which is what Algolia actually indexes).
+
+[NOTE]
+You will need a free community (or premium) link:https://www.algolia.com/users/sign_up/hacker[Algolia account] to take advantage of Algolia's indexing service and REST API.
+Simply create a named index, then visit the API Keys to collect the rest of the info you'll need to get going.
+
+To configure Algolia indexing, add a block to your main Jekyll configuration file.
+
+.Example Jekyll Algolia configuration
+[source,yaml]
+----
+algolia:
+  application_id: 'your-application-id' # <1>
+  search_only_api_key: 'your-search-only-api-key' # <2>
+  extensions_to_index: [adoc] # <3>
+----
+
+<1> From the top bar of your Algolia interface.
+<2> From the API Keys screen of your Algolia interface.
+<3> List as many extensions as apply, separated by commas.
+
+Call your same LiquiDoc build command with the `--search-index-push` or `--search-index-dry` flags along with the `--search-api-key='your-admin-api-key-here'` argument in order to invoke the indexing operation.
+The `--search-index-dry` merely tests content packaging, whereas `--search-index-push` connects to the Algolia REST API and attempt to push your content for indexing and storage.
+
+.Example Jekyll Algolia deployment
+[source,shell]
+----
+bundle exec liquidoc -c _configs/build-docs.yml --search-index-push --search-index-api-key='90f556qaa456abh6j3w7e8c10t48c2i57'
+----
+
+This operation performs a complete build, including each render operation, before the Algolia plugin processes content and pushes each build to the indexing service, in turn.
+
+[TIP]
+To add modern site search for your users, add link:https://community.algolia.com/instantsearch.js/[Algolia's InstantSearch functionality] to your front end!
 
 === Config Settings Matrix
 

--- a/README.adoc
+++ b/README.adoc
@@ -1062,6 +1062,12 @@ s| properties
 | N/A
 | Optional
 |
+
+s| search
+| N/A
+| N/A
+| Optional
+|
 |===
 
 pass:[*]The `output` setting is considered optional for render operations because static site generations target a directory set in the SSG's config file.

--- a/README.adoc
+++ b/README.adoc
@@ -901,8 +901,10 @@ The heavy lifting is performed by the jekyll-algolia plugin, but LiquiDoc can ha
 You will need a free community (or premium) link:https://www.algolia.com/users/sign_up/hacker[Algolia account] to take advantage of Algolia's indexing service and REST API.
 Simply create a named index, then visit the API Keys to collect the rest of the info you'll need to get going.
 
-To configure Algolia indexing, add a block to your main Jekyll configuration file.
+Two hard-coding steps are required to prep your source to handle Algolia index pushes.
 
+. Add a block to your main Jekyll configuration file.
++
 .Example Jekyll Algolia configuration
 [source,yaml]
 ----
@@ -911,13 +913,37 @@ algolia:
   search_only_api_key: 'your-search-only-api-key' # <2>
   extensions_to_index: [adoc] # <3>
 ----
-
++
 <1> From the top bar of your Algolia interface.
 <2> From the API Keys screen of your Algolia interface.
 <3> List as many extensions as apply, separated by commas.
 
-Call your same LiquiDoc build command with the `--search-index-push` or `--search-index-dry` flags along with the `--search-api-key='your-admin-api-key-here'` argument in order to invoke the indexing operation.
-The `--search-index-dry` merely tests content packaging, whereas `--search-index-push` connects to the Algolia REST API and attempt to push your content for indexing and storage.
+. Add a block to your build config.
++
+[source,yaml]
+----
+  - action: render
+    data: globals.yml
+    builds:
+      - backend: jekyll
+        properties:
+          files:
+            - _configs/jekyll-global.yml
+            - _configs/jekyll-portal-1.yml
+          arguments:
+            destination: build/site/user-basic
+        attributes:
+          portal_term: Guide
+        search:
+          index: 'portal-1'
+----
++
+The `index:` parameter is for the name of the index you are pushing to.
+(An Algolia “app” can have multiple “indices”.)
+If you have
+
+Now you can call your same LiquiDoc build command with the `--search-index-push` or `--search-index-dry` flags along with the `--search-api-key='your-admin-api-key-here'` argument in order to invoke the indexing operation.
+The `--search-index-dry` flag merely tests content packaging, whereas `--search-index-push` connects to the Algolia REST API and attempt to push your content for indexing and storage.
 
 .Example Jekyll Algolia deployment
 [source,shell]

--- a/lib/liquidoc.rb
+++ b/lib/liquidoc.rb
@@ -276,7 +276,7 @@ class BuildConfigStep
             text = ". #{stage}Draws data from `#{self.data[0]}`"
           end
         else
-          text = ". #{stage}Draws data from `#{self.data['file']}`"
+          text = ". #{stage}Draws data from `#{self.data}`"
         end
         text.concat("#{reason},") if reason
         text.concat(" and parses it as follows:")
@@ -654,7 +654,7 @@ def parse_regex data_file, pattern
         end
       end
     end
-    output = {"data" => records}
+    output = records
   rescue Exception => ex
     @logger.error "Something went wrong trying to parse the free-form file. #{ex.class} thrown. #{ex.message}"
     raise "Freeform parse error"
@@ -1081,7 +1081,7 @@ command_parser = OptionParser.new do|opts|
     @quiet = true
   end
 
-  opts.on("--explicit", "Log explicit step descriptions to console as build progresses. (Otherwise writes to file at #{@build_dir}/pre/config-explainer.adoc .)") do |n|
+  opts.on("--explain", "Log explicit step descriptions to console as build progresses. (Otherwise writes to file at #{@build_dir}/pre/config-explainer.adoc .)") do |n|
     explainer_init("STDOUT")
     @explainer.level = Logger::INFO
     @logger.level = Logger::WARN # Suppress all those INFO-level messages

--- a/lib/liquidoc.rb
+++ b/lib/liquidoc.rb
@@ -679,8 +679,10 @@ end
 # Parse given data using given template, generating given output
 def liquify datasrc, template_file, output, variables=nil
   input = get_data(datasrc)
-  nested = { "data" => get_data(datasrc)}
-  input.merge!nested
+  unless input['data']
+    nested = { "data" => input}
+    input.merge!nested
+  end
   validate_file_input(template_file, "template")
   if variables
     vars = { "vars" => variables }

--- a/lib/liquidoc.rb
+++ b/lib/liquidoc.rb
@@ -676,7 +676,7 @@ end
 def liquify datasrc, template_file, output, variables=nil
   input = get_data(datasrc)
   unless input['data']
-    nested = { "data" => input }
+    nested = { "data" => input.dup }
     input.merge!nested
   end
   validate_file_input(template_file, "template")

--- a/lib/liquidoc.rb
+++ b/lib/liquidoc.rb
@@ -600,11 +600,7 @@ end
 
 # Pull in a semi-structured data file, converting contents to a Ruby hash
 def ingest_data datasrc
-# Must be passed a proper data object (there must be a better way to validate arg datatypes)
-  unless datasrc.is_a? Object
-    raise "InvalidDataObject"
-  end
-  # This proc should really begin here, once the datasrc object is in order
+  raise "InvalidDataObject" unless datasrc.is_a? Object
   case datasrc.type
   when "yml"
     begin
@@ -680,7 +676,7 @@ end
 def liquify datasrc, template_file, output, variables=nil
   input = get_data(datasrc)
   unless input['data']
-    nested = { "data" => input}
+    nested = { "data" => input }
     input.merge!nested
   end
   validate_file_input(template_file, "template")


### PR DESCRIPTION
This PR facilitates the integration of Algolia search indexing of Jekyll sites sourced in AsciiDoc. This just carries over functionality already provided by the [jekyll-algolia plugin](https://github.com/algolia/jekyll-algolia). Again, LiquiDoc is just wrapping existing functionality, baking it into the LiquiDoc config structure, command-line arguments, and then triggering the functionality where appropriate. The config structure is intended to be "generic", and I would love to see it extended to other services, like Swiftype or maybe self-hosted Solr or Elastic solutions. But for my and my client market's purposes, I'm confident that Algolia is a great solution. Their [free/community tier plan](https://www.algolia.com/users/sign_up/hacker) is excellent, and they approach software in a way I appreciate.

This patch does _not_ facilitate the search query and result handling on your site. That is a theming issue to be handled in your site layout templates. I will be posing a tutorial/demo for this soon, but the clue is [Algolia's Instantsearch offering](https://community.algolia.com/instantsearch.js).