### PR TITLE
Sets empty global 'variables' param only when nonexistent

### DIFF
--- a/lib/liquidoc.rb
+++ b/lib/liquidoc.rb
@@ -346,7 +346,7 @@ class Build
     build['props'] = build['properties'] if build['properties']
     @build = build
     @type = type
-    @build['variables'] = {}
+    @build['variables'] = {} unless @build['variables']
   end
 
   def template

--- a/lib/liquidoc/version.rb
+++ b/lib/liquidoc/version.rb
@@ -1,3 +1,3 @@
 module Liquidoc
-  VERSION = "0.9.1"
+  VERSION = "0.9.2"
 end


### PR DESCRIPTION
This patch fixes the unsetting of variables passed via the config, which occurred when I applied a default value without conditionalizing. :-/ :-(