### PR TITLE
Patch 0.9.3

### DIFF
--- a/lib/liquidoc.rb
+++ b/lib/liquidoc.rb
@@ -178,6 +178,16 @@ def validate_config_structure config
 # TODO More validation needed
 end
 
+def contains_liquid filename
+  File.open(filename, "r") do |file_proc|
+    file_proc.each_line do |row|
+      if row.match(/.*\{\%.*\%\}.*|.*\{\{.*\}\}.*/)
+        return true
+      end
+    end
+  end
+end
+
 def explainer_init out=nil
   unless @explainer
     if out == "STDOUT"

--- a/lib/liquidoc.rb
+++ b/lib/liquidoc.rb
@@ -73,22 +73,24 @@ FileUtils::mkdir_p("#{@build_dir}/pre") unless File.exists?("#{@build_dir}/pre")
 # Establish source, template, index, etc details for build jobs from a config file
 def config_build config_file, config_vars={}, parse=false
   @logger.debug "Using config file #{config_file}."
-  if config_vars or parse
+  validate_file_input(config_file, "config")
+  if config_vars.length > 0 or parse or contains_liquid(config_file)
+    @logger.debug "Config_vars: #{config_vars.length}"
   # If config variables are passed on the CLI, we want to parse the config file
   # and use the parsed version for the rest fo this routine
     config_out = "#{@build_dir}/pre/#{File.basename(config_file)}"
     liquify(nil,config_file, config_out, config_vars)
     config_file = config_out
     @logger.debug "Config parsed! Using #{config_out} for build."
+    validate_file_input(config_file, "config")
   end
-  validate_file_input(config_file, "config")
   begin
     config = YAML.load_file(config_file)
-  rescue
+  rescue Exception => ex
     unless File.exists?(config_file)
       @logger.error "Config file #{config_file} not found."
     else
-      @logger.error "Problem loading config file #{config_file}. Exiting."
+      @logger.error "Problem loading config file #{config_file}. #{ex} Exiting."
     end
     raise "ConfigFileError"
   end

--- a/lib/liquidoc.rb
+++ b/lib/liquidoc.rb
@@ -943,12 +943,15 @@ def generate_site doc, build
     File.open("#{@build_dir}/pre/_attributes.yml", 'w') { |file| file.write(attrs_yaml) }
     build.add_config_file("#{@build_dir}/pre/_attributes.yml")
     config_list = build.prop_files_array.join(',') # flatten the Array back down for the CLI
-    opts_args = ""
     quiet = "--quiet" if @quiet || @explicit
     if build.props['arguments']
-      opts_args = build.props['arguments'].to_opts_args
+      opts_args_file = "#{@build_dir}/pre/jekyll_opts_args.yml"
+      opts_args = build.props['arguments']
+      File.open(opts_args_file, 'w') { |file|
+      file.write(opts_args.to_yaml)}
+      config_list << ",#{opts_args_file}"
     end
-    base_args = "--config #{config_list} #{opts_args}"
+    base_args = "--config #{config_list}"
     command = "bundle exec jekyll build #{base_args} #{quiet}"
     if @search_index
       # TODO enable config-based admin api key ingest once config is dynamic

--- a/lib/liquidoc/version.rb
+++ b/lib/liquidoc/version.rb
@@ -1,3 +1,3 @@
 module Liquidoc
-  VERSION = "0.9.2"
+  VERSION = "0.9.3"
 end


### PR DESCRIPTION
This patch addresses a couple of bugs.

1. Dynamic build parsing was not triggered by sensible conditions
   Config files are now parsed under these conditions:
   * explicit `--parse-config` flag on command line
   * passing of any `--var key=value` on the CLI during a config build
   * existence of Liquid tags in config file

1. Jekyll config arguments from build configs are passed in an additional config file rather than as appended CLI arguments.