### PR TITLE
Update readme for inclusion in ldcmf guides & general cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,3 @@
-= LiquiDoc
 // This AsciiDoc file must be rendered to be properly viewed.
 // The easiest way to view it rendered is on BitBucket
 // OR copy and paste these contents into
@@ -9,12 +8,13 @@
 // THESE ATTRIBUTES ARE FOR THE README file specifically
 // They will be replaced in the main build by data from
 // data/meta.yml and other files
+= LiquiDoc
 :sfx:
 :show_admin: true
 :xref_source-markup-liquid-basics: liquid-templating
 :xref_build-config-dynamic: dynamic-config
 :xref_build-config-file-local: self-doc-config
-:toc:
+:toc: preamble
 
 // tag::overview[]
 LiquiDoc is a documentation build utility for true single-sourcing of technical content and data.

--- a/README.adoc
+++ b/README.adoc
@@ -43,12 +43,9 @@ LiquiDoc is a build tool for software-documentation projects or for the document
 Unlike tools that are mere converters, LiquiDoc can be configured to perform multiple consecutive routines for generating content from multiple data/content sources, each output in various formats based on distinct templates and themes.
 It can be integrated into build- and package-management systems and deployed for continuous integration (CI).
 
-.LiquiDoc is “AJYL”
-====
 LiquiDoc pulls together the underlying “*AJYL*” technologies: link:https://asciidoctor.org/docs/what-is-asciidoc/[AsciiDoc technical markup] (via link:https://github.com/asciidoctor/asciidoctor[Asciidoctor]), link:https://en.wikipedia.org/wiki/YAML[YAML data structures], and the link:https://shopify.github.io/liquid/[Liquid templating format/engine], built using the link:https://jekyllrb.com/[Jekyll static-site generator] and link:https://jamstack.org/[JAMstack components and services] for publishing and delivery.
 It is developed in coordination with the link:https://ajyl.org/liquidoc-cmf[LiquiDoc Content Management Framework], a recommended architecture, strategies, and conventions for building robust documents with LiquiDoc.
 LiquiDoc itself is fairly open-ended, supporting various configurations of dependent platforms Jekyll and Asciidoctor.
-====
 
 The utility currently provides for basic configuration of build jobs, and it can be incorporated into build toolchains.
 The gem does not have a formalized Ruby API yet, but the command-line interface is very powerful, especially combined with build configs formatted in YAML enhanced by Liquid markup for dynamic parsing of routines at buildtime. (See <<{xref_build-config-dynamic}>>.)

--- a/README.adoc
+++ b/README.adoc
@@ -30,7 +30,7 @@ LiquiDoc relies heavily on the Asciidoctor rendering engine, which produces HTML
 Output can be pretty much any flat file, with automatic data conversions to JSON and YAML, as well as rich-text/multimedia formats like HTML, PDF, slide decks, and more.
 // end::overview[]
 
-toc::
+toc::[]
 
 // tag::rocana-note[]
 [NOTE]
@@ -46,7 +46,7 @@ LiquiDoc is a build tool for software-documentation projects or for the document
 Unlike tools that are mere converters, LiquiDoc can be configured to perform multiple consecutive routines for generating content from multiple data/content sources, each output in various formats based on distinct templates and themes.
 It can be integrated into build- and package-management systems and deployed for continuous integration (CI).
 
-LiquiDoc pulls together the underlying “AJYL” technologies: link:https://asciidoctor.org/docs/what-is-asciidoc/[AsciiDoc technical markup] (via link:https://github.com/asciidoctor/asciidoctor[Asciidoctor]), link:https://en.wikipedia.org/wiki/YAML[YAML data structures], and the link:https://shopify.github.io/liquid/[Liquid templating format/engine], built using the link:https://jekyllrb.com/[Jekyll static-site generator] and link:https://jamstack.org/[JAMstack components and services] for publishing and delivery.
+LiquiDoc pulls together the underlying “*AJYL*” technologies: link:https://asciidoctor.org/docs/what-is-asciidoc/[AsciiDoc technical markup] (via link:https://github.com/asciidoctor/asciidoctor[Asciidoctor]), link:https://en.wikipedia.org/wiki/YAML[YAML data structures], and the link:https://shopify.github.io/liquid/[Liquid templating format/engine], built using the link:https://jekyllrb.com/[Jekyll static-site generator] and link:https://jamstack.org/[JAMstack components and services] for publishing and delivery.
 It is developed in coordination with the link:https://ajyl.org/liquidoc-cmf[LiquiDoc Content Management Framework], a recommended architecture, strategies, and conventions for building robust documents with LiquiDoc.
 LiquiDoc itself is fairly open-ended, supporting various configurations of dependent platforms Jekyll and Asciidoctor.
 

--- a/README.adoc
+++ b/README.adoc
@@ -43,9 +43,12 @@ LiquiDoc is a build tool for software-documentation projects or for the document
 Unlike tools that are mere converters, LiquiDoc can be configured to perform multiple consecutive routines for generating content from multiple data/content sources, each output in various formats based on distinct templates and themes.
 It can be integrated into build- and package-management systems and deployed for continuous integration (CI).
 
+.LiquiDoc is “AJYL”
+====
 LiquiDoc pulls together the underlying “*AJYL*” technologies: link:https://asciidoctor.org/docs/what-is-asciidoc/[AsciiDoc technical markup] (via link:https://github.com/asciidoctor/asciidoctor[Asciidoctor]), link:https://en.wikipedia.org/wiki/YAML[YAML data structures], and the link:https://shopify.github.io/liquid/[Liquid templating format/engine], built using the link:https://jekyllrb.com/[Jekyll static-site generator] and link:https://jamstack.org/[JAMstack components and services] for publishing and delivery.
 It is developed in coordination with the link:https://ajyl.org/liquidoc-cmf[LiquiDoc Content Management Framework], a recommended architecture, strategies, and conventions for building robust documents with LiquiDoc.
 LiquiDoc itself is fairly open-ended, supporting various configurations of dependent platforms Jekyll and Asciidoctor.
+====
 
 The utility currently provides for basic configuration of build jobs, and it can be incorporated into build toolchains.
 The gem does not have a formalized Ruby API yet, but the command-line interface is very powerful, especially combined with build configs formatted in YAML enhanced by Liquid markup for dynamic parsing of routines at buildtime. (See <<{xref_build-config-dynamic}>>.)

--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,7 @@ toc::
 [NOTE]
 While the first two releases of LiquiDoc were published under the MIT license by my former employer, I do not believe the https://github.com/scalingdata/liquidoc-gem[originating repo] will be maintained.
 Therefore, as of version 0.3.0, I maintain this fork under the MIT license.
-More in <<Contributing>> and <<License>>.
+More in <<Contributing>> and <<Licensing>>.
 
 // end::rocana-note[]
 
@@ -59,7 +59,7 @@ From any given data file, multiple template-driven parsing operations can be per
 
 Upcoming capabilities include a secondary publish function for generating link:http://asciidoctor.org/[Asciidoctor] output from data-driven AsciiDoc-formatted files to ePub and even HTML/JavaScript slide presentations.
 
-See this link:https://github.com/briandominick/liquidoc-gem/issues?q=label%3Aenhancement[project's GitHub issues] for upcoming features, and feel free to add your own requests.
+See this link:https://github.com/DocOps/liquidoc-gem/issues?q=label%3Aenhancement[project's GitHub issues] for upcoming features, and feel free to add your own requests.
 // end::purpose[]
 
 // tag::installation[]
@@ -183,7 +183,7 @@ Can also be `stdout` to write to console.
 ----
 - action: parse
   data: # <1>
-    file: source_data_file.json # <2>
+    file: source_data_file.txt # <2>
     type: regex # <3>
     pattern: (?<kee>[A-Z0-9_]+)\s(?<valu>.*)\n # <4>
   builds:
@@ -267,8 +267,7 @@ timeout,The duration of a session (in seconds),300,false
 ----
 
 The above source data, parsed as a CSV file, will yield an _array_ of hashes.
-Each array item represents a row from the CSV file (except the first row, which establishes parameter keys).
-Each array item contains a _structure_, or what Ruby calls a _hash_.
+Each array item is a _structure_ -- what Ruby calls a _hash_ -- representing a row from the source file (except the first row, which establishes parameter keys).
 As represented in the CSV example above, if the structure contains more than one key-value pair (more than one “column” in the source), all such pairs will be siblings, not nested or hierarchical.
 
 .Example -- array derived from sample.csv, with values depicted
@@ -284,18 +283,19 @@ data[1].default #=> 300
 data[1].required #=> false
 ----
 
-===== Free-form Data
+===== Unstructured Data
 
-Free-form data can only be parsed using regular expression (“regex”) patterns -- otherwise LiquiDoc has no idea what to consider data and what to consider noise, let alone how to label and structure the data.
+Unstructured data files can be ingested as well, as long as records are delineated by lines (as with CSV) _and_ each line meets a consistent pattern we can “scrape” for data to organize.
+This method generates arrays of structures similarly to the CSV approach.
 
+Unstructured records are parsed into using regular expression (“regex”) patterns.
 Any file organized with one record per line may be consumed and parsed by LiquiDoc, provided you tell the parser which variables to extract from where.
-The parser will read each line individually, applying your regex pattern to extract data using named groups.
+The parser will read each line individually, applying your regex pattern to extract data using named groups then storing them as variables for the associated parsing action.
 
 [TIP]
 .Learn regular expressions
-If you're already familiar enough with regex, this note is not for you.
 If you deal with docs but are not a regex user, become one.
-I promise you will deem the initial hurdles worth surmounting.
+They are increedibly powerful and can save hours of error-prone manual work such as complex find and replace.
 
 .Example -- sample.free free-form data source file
 ----
@@ -797,7 +797,7 @@ Imagine this affecting content in the book file.
 \include::chapter-1.adoc[]
 
 \include::chapter-2.adoc[]
-\ifeval::[{edition} == "Special"]
+\ifeval::["{edition}" == "Special"]
 \include::chapter-3.adoc[]
 \endif::[]
 ----
@@ -808,15 +808,14 @@ Not only are we setting the subtitle with a variable; if we're building the spec
 
 [[command-line-arguments]]
 Command-line arguments::
-There is yet a way to override all of this, which is also handy for testing variables out without editing any files:
-pass arguments via the `-a` command-line argument.
+There is yet a way to override all of this, which is also handy for testing variables out without editing any files: pass arguments via the `-a` option on the command line.
 The `-a` option flag accepts an argument in the format of `key=value`, where `key` is the name of your attribute, and `value` is your optional assignment for that attribute.
 You may pass as many attributes as you like this way, up to the capacity of your shell's command line, which is probably something.
 +
 [source,bash]
 .Example -- Setting global build attributes on the CLI
 ----
-bundle exec liquidoc -c _configs/my_book.yml -a edition='Very Special NSFW' -a testvar=working
+bundle exec liquidoc -c _configs/my_book.yml -a edition='Very Special NSFW'
 ----
 
 [[more-data]]
@@ -918,7 +917,8 @@ For now, this functionality is limited to adding a `--deploy` flag to your `liqu
 This will attempt to serve files from the `destination:` set for the associated Jekyll build.
 
 [WARNING]
-Deployment of Jekyll sites is both limited and untested under nonstandard conditions.
+LiquiDoc-automated deployment of Jekyll sites is both limited and untested under nonstandard conditions.
+Non-local deployment should be handled by external continuous-integration/devlopment (CICD) tools.
 
 ==== Algolia Search Indexing for Jekyll
 

--- a/README.adoc
+++ b/README.adoc
@@ -14,14 +14,12 @@
 :xref_source-markup-liquid-basics: liquid-templating
 :xref_build-config-dynamic: dynamic-config
 :xref_build-config-file-local: self-doc-config
-:toc: macro
+:toc: preamble
 
 // tag::overview[]
 LiquiDoc is a documentation build utility for true single-sourcing of technical content and data.
 It is especially suited for documentation projects with various required output formats from complex, single-sourced codebases, but it is intended for any project with complex, versioned input data for use in docs, user interfaces, and even back-end code.
 The highly configurable command-line utility (and Ruby gem) engages template engines to parse complex data into rich text output, from *blogs* to *books* to *knowledge bases* to *slide presentations*.
-
-toc::[]
 
 Sources can be flat files in formats such as *XML* (eXtensible Markup Language), *JSON* (JavaScript Object Notation), *CSV* (comma-separated values), and our preferred human-editable format: *YAML* (acronym link:https://en.wikipedia.org/wiki/YAML#History_and_name[in dispute]).
 LiquiDoc also accepts *regular expressions* to parse unconventionally formatted files.

--- a/README.adoc
+++ b/README.adoc
@@ -1,44 +1,60 @@
 = LiquiDoc
-:toc: preamble
+// This AsciiDoc file must be rendered to be properly viewed.
+// The easiest way to view it rendered is on BitBucket
+// OR copy and paste these contents into
+// https://asciidoclive.com
+// BELOW is all AsciiDoc formatting:
+// https://asciidoctor.org/docs/what-is-asciidoc/
+
+// THESE ATTRIBUTES ARE FOR THE README file specifically
+// They will be replaced in the main build by data from
+// data/meta.yml and other files
+:sfx:
+:show_admin: true
+:xref_source-markup-liquid-basics: liquid-templating
+:xref_build-config-dynamic: dynamic-config
+:xref_build-config-file-local: self-doc-config
+
+:toc: macro
 
 // tag::overview[]
 LiquiDoc is a documentation build utility for true single-sourcing of technical content and data.
-It is especially suited for documentation projects with various required output formats, but it is intended for any project with complex, versioned input data for use in docs, user interfaces, and even back-end code.
-The highly configurable command-line utility engages template engines to parse complex data into rich text output, from *blogs* to *books* to *knowledge bases* to *slide presentations*.
+It is especially suited for documentation projects with various required output formats from complex, single-sourced codebases, but it is intended for any project with complex, versioned input data for use in docs, user interfaces, and even back-end code.
+The highly configurable command-line utility (and Ruby gem) engages template engines to parse complex data into rich text output, from *blogs* to *books* to *knowledge bases* to *slide presentations*.
 
 Sources can be flat files in formats such as *XML* (eXtensible Markup Language), *JSON* (JavaScript Object Notation), *CSV* (comma-separated values), and our preferred human-editable format: *YAML* (acronym link:https://en.wikipedia.org/wiki/YAML#History_and_name[in dispute]).
 LiquiDoc also accepts *regular expressions* to parse unconventionally formatted files.
 
-LiquiDoc relies heavily on the Asciidoctor rendering engine, which produces HTML, PDF, and soon several other rich-text output formats.
+LiquiDoc relies heavily on the Asciidoctor rendering engine, which produces HTML and PDF documents as well as complete static websites, the latter via Jekyll.
 
-Output can (or will) be pretty much any flat file, including semi-structured data like JSON and XML, as well as rich text/multimedia formats like HTML, PDF, slide decks, and more.
+Output can be pretty much any flat file, with automatic data conversions to JSON and YAML, as well as rich-text/multimedia formats like HTML, PDF, slide decks, and more.
 // end::overview[]
+
+toc::
+
 // tag::rocana-note[]
 [NOTE]
-While the first two releases of LiquiDoc were released under the MIT license by my former employer, I do not believe the https://github.com/scalingdata/liquidoc-gem[originating repo] will be maintained.
+While the first two releases of LiquiDoc were published under the MIT license by my former employer, I do not believe the https://github.com/scalingdata/liquidoc-gem[originating repo] will be maintained.
 Therefore, as of version 0.3.0, I maintain this fork under the MIT license.
-More below under <<Contributing>> and <<License>>.
+More in <<Contributing>> and <<License>>.
 
 // end::rocana-note[]
 
 == Purpose
 // tag::purpose[]
-LiquiDoc is a build tool for documentation projects or for the documentation component of a larger project.
-Unlike tools that are mere converters, LiquiDoc can be easily configured to perform multiple consecutive routines for generating content from multiple data/content source files, each output in various formats based on distinct templates and themes.
+LiquiDoc is a build tool for software-documentation projects or for the documentation component of a larger software project.
+Unlike tools that are mere converters, LiquiDoc can be configured to perform multiple consecutive routines for generating content from multiple data/content sources, each output in various formats based on distinct templates and themes.
 It can be integrated into build- and package-management systems and deployed for continuous integration (CI).
 
-The tool currently provides for very basic configuration of build jobs.
-The gem does not have a formalized Ruby API yet, but the command-line interface and configuration options are very powerful together.
-From any given data file, multiple template-driven parsing operations can be performed to produce totally different output formats from the same dataset.
-Build configurations enable such operations from a single command.
+LiquiDoc pulls together the underlying “AJYL” technologies: link:https://asciidoctor.org/docs/what-is-asciidoc/[AsciiDoc technical markup] (via link:https://github.com/asciidoctor/asciidoctor[Asciidoctor]), link:https://en.wikipedia.org/wiki/YAML[YAML data structures], and the link:https://shopify.github.io/liquid/[Liquid templating format/engine], built using the link:https://jekyllrb.com/[Jekyll static-site generator] and link:https://jamstack.org/[JAMstack components and services] for publishing and delivery.
+It is developed in coordination with the link:https://ajyl.org/liquidoc-cmf[LiquiDoc Content Management Framework], a recommended architecture, strategies, and conventions for building robust documents with LiquiDoc.
+LiquiDoc itself is fairly open-ended, supporting various configurations of dependent platforms Jekyll and Asciidoctor.
 
-=== Single-sourcing Docs _and_ Code
+The utility currently provides for basic configuration of build jobs, and it can be incorporated into build toolchains.
+The gem does not have a formalized Ruby API yet, but the command-line interface is very powerful, especially combined with build configs formatted in YAML enhanced by Liquid markup for dynamic parsing of routines at buildtime. (See <<{xref_build-config-dynamic}>>.)
+From any given data file, multiple template-driven parsing operations can be performed to produce totally different output formats from the same content and data sources.
 
-A datasource file in the simplest, most manageable format applicable to the job and preferred by the team can serve as the canonical authority.
-But rather than using this file as a mere _reference_ like most docs, every stakeholder on the team can draw from it _programmatically_.
-Feature teams that need structured data in different formats can read the semi-structured source file from a common location in the repository and parse it using native libraries.
-Alternatively, LiquiDoc can parse it into a generated source file during the product build procedure and save a copy in the target/build tree for the application build to pick up.
-
+[[roadmap]]
 === Coming Soon
 
 Upcoming capabilities include a secondary publish function for generating link:http://asciidoctor.org/[Asciidoctor] output from data-driven AsciiDoc-formatted files to ePub and even HTML/JavaScript slide presentations.
@@ -76,7 +92,7 @@ gem 'liquidoc'
 ----
 +
 [TIP]
-This file is included in the link:https://github.com/briandominick/liquidoc-boilerplate[LiquiDoc boilerplate files].
+A version of this file is included in the link:https://github.com/DocOps/liquidoc-cmf[LiquiDoc CMF bootstrap repo], which is a recommended way to quickstart or demo a LiquiDoc CMF application.
 
 . Open a terminal (command prompt).
 +
@@ -106,26 +122,31 @@ These definitions can be command-line options, or they can be instructed by pres
 
 [TIP]
 .Quickstart
-If you want to try the tool out with dummy data and templates, clone link:https://github.com/briandominick/liquidoc-boilerplate[this boilerplate repo] and run the suggested commands.
+If you want to try the tool out with dummy data and templates, clone the link:https://github.com/DocOps/liquidoc-cmf[LiquiDoc CMF bootstrap repo] and run the suggested commands.
+This will set you up with an architecture and starter files, including a basic build config.
+
+=== Basic Parsing
 
 Give LiquiDoc (1) any proper YAML, JSON, XML, or CSV (with header row) data file and (2) a template mapping any of the data to token variables with Liquid markup -- LiquiDoc returns STDOUT feedback or writes a new file (or multiple files) based on that template.
 
 .Example -- Generate sample output from files passed as CLI arguments
 ----
-bundle exec liquidoc -d _data/data-sample.yml -t _templates/liquid/sample.asciidoc -o _output/sample.adoc
+bundle exec liquidoc -d _data/sample.yml -t _templates/liquid/sample.asciidoc -o _output/sample.adoc
 ----
 
+This single-action invocation of LiquiDoc ingests data from YAML file `sample.yml`, reads __Liquid__-formatted template `sample.asciidoc`, and generates __AsciiDoc__-formatted file `sample.adoc`
+
 [TIP]
-Add `--verbose` to see the steps LiquiDoc is taking.
+Add `--verbose` to any `liquidoc` command to see the steps the utility is taking.
 
 // end::usage-intro[]
 
 === Configuration
 // tag::configuration[]
 The best way to use LiquiDoc is with a configuration file.
-This not only makes the command line much easier to manage (requiring just a configuration file path argument), it also adds the ability to perform more complex builds and manage them with source control.
+This not only makes the command line much easier to manage (requiring just a configuration file path argument), it also adds the ability to perform more complex build routines and manage them with source control.
 
-Here is very simple build routine as instructed by a LiquiDoc config:
+Here is very simple build routine instructed by a LiquiDoc config:
 
 [source,yaml]
 .Example config file for recognized-format parsing
@@ -140,20 +161,20 @@ Here is very simple build routine as instructed by a LiquiDoc config:
 ----
 
 <1> The top-level `-` denotes a new, consecutively executed “step” in the build.
-The *action* parameter determines what type of action this step will perform.
+The `action:` parameter determines what type of action this step will perform.
 The options are `parse`, `migrate`, `render`, and `deploy`.
 
-<2> If the *data* setting's value is a string, it must be the filename of a format automatically recognized by LiquiDoc: `.yml`, `.json`, `.xml`, or `.csv`.
-Otherwise, *data* must contain child settings for *file* and *type*.
+<2> If the `data:` setting's value is a string, it must be the filename of a format automatically recognized by LiquiDoc: `.yml`, `.json`, `.xml`, or `.csv`.
+Otherwise, `data:` must contain subordinate settings for `file:` and `type:`.
 
-<3> The *builds* section contains a list of procedures to perform on the data.
+<3> The `builds:` section contains a list of procedures to perform on the data.
 It can include as many subroutines as you wish to perform.
 This one instructs two builds.
 
-<4> The *template* setting should be a liquid-formatted file (see <<templating>> below).
+<4> The `template:` setting should be a liquid-formatted file (see <<{xref_source-markup-liquid-basics}>>).
 
-<5> The *output* setting is a path and filename where you wish the output to be saved.
-Can also be `stdout`.
+<5> The `output:` setting is a path and filename where you wish the output to be saved.
+Can also be `stdout` to write to console.
 
 .Advanced Data Ingest
 ****
@@ -173,12 +194,12 @@ Can also be `stdout`.
   stage: parse-my-file # <5>
 ----
 
-<1> In this format, the *data* setting contains several other settings.
+<1> In this format, the `data:` setting contains several other settings.
 
-<2> The *file* setting accepts _any_ text file, no matter the file extension or data formatting within the file.
+<2> The `file:` setting accepts _any_ text file, no matter the file extension or data formatting within the file.
 This field is required.
 
-<3> The *type* field can be set to `regex` if you will be using a regular expression pattern to extract data from lines in the file.
+<3> The `type:` field can be set to `regex` if you will be using a regular expression pattern to extract data from lines in the file.
 It can also be set to `yml`, `json`, `xml`, or `csv` if your file is in one of these formats but uses a nonstandard extension.
 
 <4> If your type is `regex`, you must supply a regular expression pattern.
@@ -186,7 +207,7 @@ This pattern will be applied to each line of the file, scanning for matches to t
 Your pattern must contain at least one group, denoted with unescaped `(` and `)` markers designating a “named group”, denoted with `?<string>`, where `string` is the name for the variable to assign to any content matching the pattern contained in the rest of the group (everything else between the unescaped parentheses.).
 
 <5> _Optionally_, you can tag any top-level step with a label.
-This will be expressed <<self-documenting-configuration,during logging>>, and eventually it will enable us to suppress or reorder steps by name (see link:https://github.com/DocOps/liquidoc-gem/issues/33[Issue #33]).
+This will be expressed during logging, and eventually it will enable us to suppress or reorder steps by name (see link:https://github.com/DocOps/liquidoc-gem/issues/33[Issue #33]).
 ****
 
 When you have established a configuration file, you can call it with the option `-c` on the command line.
@@ -197,7 +218,7 @@ bundle exec liquidoc -c _configs/cfg-sample.yml --stdout
 ----
 
 [TIP]
-Repeat without the `--stdout` flag, and you'll find the generated files in `_build/`, as defined in the configuration.
+Repeat without the `--stdout` flag, and you'll find the generated files in `_output/`, as defined in the configuration.
 
 // tag::configuration[]
 
@@ -217,7 +238,7 @@ The native nested formats are actually the most straightforward.
 So long as your filename has a conventional extension, you can just pass a file path for this setting.
 That is, if your file ends in `.yml`, `.json`, or `.xml`, and your data is properly formatted, LiquiDoc will parse it appropriately.
 
-For standard-format files that have non-standard file extensions (for example, `.js` rather than `.json` for a JSON file), you must declare a type explicitly.
+For standard-format files that have non-standard file extensions (for example, `.js` rather than `.json` for a JSON-formatted file), you must declare a type explicitly.
 
 [source,yaml]
 .Example config -- Instructing correct type for mislabeled JSON file
@@ -231,7 +252,7 @@ For standard-format files that have non-standard file extensions (for example, `
       output: _output/output_file.html
 ----
 
-Once LiquiDoc knows the right file type, it will parse the file into a Ruby hash data structure for further processing.
+Once LiquiDoc knows the right file type, it will parse the file into a Ruby object for further processing.
 
 ===== CSV Data
 
@@ -245,8 +266,8 @@ enabled,Whether project is active,,true
 timeout,The duration of a session (in seconds),300,false
 ----
 
-The above source data, parsed as a CSV file, will yield an _array_.
-Each array item represents a row from the CSV file (except the first row).
+The above source data, parsed as a CSV file, will yield an _array_ of hashes.
+Each array item represents a row from the CSV file (except the first row, which establishes parameter keys).
 Each array item contains a _structure_, or what Ruby calls a _hash_.
 As represented in the CSV example above, if the structure contains more than one key-value pair (more than one “column” in the source), all such pairs will be siblings, not nested or hierarchical.
 
@@ -265,7 +286,7 @@ data[1].required #=> false
 
 ===== Free-form Data
 
-Free-form data can only be parsed using regex patterns -- otherwise LiquiDoc has no idea what to consider data and what to consider noise.
+Free-form data can only be parsed using regular expression (“regex”) patterns -- otherwise LiquiDoc has no idea what to consider data and what to consider noise, let alone how to label and structure the data.
 
 Any file organized with one record per line may be consumed and parsed by LiquiDoc, provided you tell the parser which variables to extract from where.
 The parser will read each line individually, applying your regex pattern to extract data using named groups.
@@ -303,7 +324,7 @@ Let's take a closer look at that regex pattern.
 ^(?<code>[A-Z_]+)\s(?<description>.*)\s(?<required>true|false)\n
 ----
 
-We see the named groups *code*, *description*, and *required*.
+We see the named groups `code`, `description`, and `required`.
 This maps nicely to a new array.
 
 .Example -- array derived from sample.free using above regex pattern
@@ -321,12 +342,12 @@ Free-form/regex parsing is obviously more complicated than the other data types.
 Its use case is usually when you simply cannot control the form your source takes.
 
 The regex type is also handy when the content of some fields would be burdensome to store in conventional semi-structured formats like those natively parsed by LiquiDoc.
-This is the case for jumbled content containing characters that require escaping, so you can keep source like that from the example above in the simplest possible form.
+This is the case for jumbled content containing characters that require escaping, so you can store source matter like that from the example above in the rawest possible form.
 
 ==== Default Output Formats
 
-LiquiDoc can directly convert any semi-structured data input format to either YAML or JSON output.
-Simply provide no template, and make sure the output file has a proper extension (`.yml` or `.json`).
+LiquiDoc can directly convert any supported semi-structured data input format to either YAML or JSON output.
+Simply provide no template parameter, and make sure the output file has a proper extension (`.yml` or `.json`).
 
 .Example config snippet for data-to-data conversion
 [source,yaml]
@@ -336,15 +357,18 @@ Simply provide no template, and make sure the output file has a proper extension
   output: _build/frontend/testdata.json
 ----
 
-XML and CSV output will be added in a future release.
+[NOTE]
+This feature is in need of validation.
+XML and CSV output will be added in a future release if direct conversions prove useful.
 
-==== Templating
+[[liquid-templating]]
+==== Templating with Liquid
 
-link:https://help.shopify.com/themes/liquid/basics[*Liquid*] is used for parsing complex variable data, typically for iterated output.
+Shopify's open-source link:https://help.shopify.com/themes/liquid/basics[*Liquid*] templating language and engine are used for parsing complex variable data in plaintext markup, typically for generating iterated (looping) output.
 For instance, a data structure of glossary terms and definitions that needs to be looped over and pressed into a more publish-ready markup, such as Markdown, AsciiDoc, reStructuredText, LaTeX, or HTML.
 
 Any valid Liquid-formatted template is accepted, in the form of a text file with any extension.
-For data sourced in CSV format or extracted through regex source parsing, all data is passed to the Liquid template parser as an array called *data*, containing one or more rows to be iterated through.
+For data sourced in CSV format or extracted through regex source parsing, all data is passed to the Liquid template parser as an array called `data:`, containing one or more rows to be iterated through.
 Data sourced in YAML, XML, or JSON may be passed as complex structures with custom names determined in the file contents.
 
 Looping through known data formats is fairly straightforward.
@@ -352,7 +376,7 @@ A _for_ loop iterates through your data, item by item.
 Each item or row contains one or more key-value pairs.
 
 [[rows_asciidoc]]
-.Example -- rows.asciidoc Liquid template
+.Example -- rows.asciidoc Liquid template for outputting AsciiDoc plaintext markup
 [source,liquid]
 ----
 {% for row in data %}{{ row.name }}::
@@ -365,20 +389,22 @@ Required:: {% if row.required == "true" %}*Yes*{% else %}No{% endif %}
 
 In <<rows_asciidoc>>, we're instructing Liquid to iterate through our data items, generating a data structure called `row` each time.
 The double-curly-bracketed tags convey variables to evaluate.
-This means `{{ row.name }}` is intended to express the value of the *name* parameter in the item presently being parsed.
+This means `{{ row.name }}` is intended to express the value of the `name` parameter in the item presently being parsed.
 The other curious marks such as `::` and `[horizontal.simple]` are AsciiDoc markup -- they are the formatting we are trying to introduce to give the content form and semantic relevance.
 
 .Non-printing Markup
 ****
 In Liquid and most templating systems, any row containing a non-printing “tag” will leave a blank line in the output after parsing.
-For this reason, it is advised that you stack tags horizontally when you do not wish to generate a blank line, as with the first row above.
-A non-printing tag such as `{% endfor %}` will generate a blank line that is inconvenient in the output.
+One solution is to stack tags horizontally when you do not wish to generate a blank line, as with the first row above.
+However, a non-printing tag such as `{% endfor %}` will generate a blank line that can be inconvenient in the output.
 
 This side effect of templating is unfortunate, as it discourages elegant, “accordian-style” code nesting, like you see in the HTML example below (<<parsed_html>>).
+Unlike most templating formats, however, Liquid offers highly effective link:https://shopify.github.io/liquid/basics/whitespace/[whitespace control] capability.
+This additional markup is not always worth the time but can come in quite handy, especially when generating markup where indentation matters.
 In the end, ugly Liquid templates can generate quite elegant markup output with exquisite precision.
 ****
 
-The above would generate the following:
+The above (<<rows_asciidoc>>) would generate the following:
 
 [[asciidoc_formatted_source]]
 .Example -- AsciiDoc-formatted output
@@ -470,7 +496,7 @@ G_H Some text for &hdf 1t`F false
 
 In addition to data files, parse operations accept fixed variables and environment variables.
 
-*Fixed variables* are passed as a _per-build_ structure called `variables:` in the config file.
+*Fixed variables* are defined using a _per-build_ structure called `variables:` in the config file.
 Each build operation can accept a distinct set of variables.
 
 [source,yaml]
@@ -509,16 +535,17 @@ Inside that template, we might find a block of Liquid code hiding some navigatio
 {% endif %}
 ----
 
-
+This portion of the example config presses two versions of the Liquid template `side-nav.html` into two different nav menus, either to be served on two parallel sites or one site with the ability to select front-end elements depending on user status.
+In this example, only the menu shown to premium users will contain the billing link; basic users will see an upgrade prompt.
 
 ==== Output
 
-After this parsing, files are written in any of the given output formats, or else just written to system as STDOUT (when you add the `--stdout` flag to your command or set `output: stdout` in your config file).
-Liquid templates can be used to produce any flat-file format imaginable.
+After this parsing, files are written in any of the given output formats, or else just written to console as STDOUT (when you add the `--stdout` flag to your command or set `output: stdout` in your config file).
+Liquid templates can be used to produce any plaintext format imaginable.
 Just format valid syntax with your source data and Liquid template, then save with the proper extension, and you're all set.
 
 === Migrate Operations
-
+// tag::migrate-operations[]
 During the build process, different tools handle file assets variously, so your images and other embedded files are not always where they need to be relative to the current procedure.
 Migrate actions copy resource files to a temporary/uncommitted directory during the build procedure so they can be readily accessed by subsequent steps.
 
@@ -538,14 +565,15 @@ In addition to designating `action: migrate`, migrate operations require just a 
 ----
 
 The first action step above copies all the files and folders in `assets/images` and adds them to `_build/img`.
-It will only recreate the contents of the source directory, not the directory path itself, because the *inclusive* option is set to `false` (though its default is `true`).
+It will only recreate the contents of the source directory, not the directory path itself, because the `inclusive:` option is set to `false` (its default value is `true`).
 When both the source and target paths are directories and inclusive is `true`, the files are copied to `target/source/`.
 When inclusive is `false`, they copy to `target/`.
 
-Individual files must be listed in individual steps at this time, one per step, as in the second step above.
+Individual files must be listed in individual steps, one per step, as in the second step above.
+// end::migrate-operations[]
 
 === Render Operations
-
+// tag::render-operations[]
 Presently, all render actions convert AsciiDoc-formatted source files into rich-text documents, such as PDFs and HTML pages.
 LiquiDoc uses Asciidoctor's Ruby engine and various other plugins to generate output in a few supported formats.
 
@@ -556,16 +584,15 @@ First let's look at a render action configuration step.
 ----
 - action: render
   source: book-index.adoc
-  data: _config/asciidoctor.yml
+  data: _configs/asciidoctor.yml
   builds:
     - output: _build/publish/codewriting-book-draft.pdf
       theme: theme/pdf-theme.yml
     - output: _build/publish/codewriting-book-draft.html
       theme: theme/site.css
-    - output: _build/publish/codewriting-book-draft.epub
 ----
 
-Each render action requires an index, which is the primary AsciiDoc file to process labeled *source* in our configuration.
+Each action for rendering a conventionally structured book-style document requires an index, which is the primary AsciiDoc file to process labeled `source:` in our configuration.
 This file can contain all of your AsciiDoc content, if you wish.
 Alternatively, it can be made up entirely of `include::` macros, creating an linear map of your document's contents, which may themselves be more AsciiDoc files, code examples, and so forth.
 
@@ -609,7 +636,7 @@ to demonstrate inclusion.
 // end::booksample[]
 ----
 
-The third instruction in our <<_fig_index_file>>, which was simply include::code-sample.js[lines="22..33"] -- this dangerous little bugger extracts a fixed span of code lines, as designated.
+The third instruction in our <<_fig_index_file>>, which was simply `include::code-sample.js[lines="22..33"]` -- this dangerous little bugger extracts a fixed span of code lines, as designated.
 
 ==== Static Site Render Operations
 
@@ -642,21 +669,21 @@ This is established in your build-config block
         portal_term: Guide
 ----
 
-The *backend* designation of `jekyll` is required, and at least one file under *properties* > *files* is strongly encouraged for proper Jekyll behavior.
-LiquiDoc will write an additional YAML file containing all of the AsciiDoctor attributes, to be appended to this list when the build command is run.
-This captures attributes offered up in the action-level *data* file and in the *attributes* section of the *build* step.
+The `backend:` designation of `jekyll` is required, and at least one file under `properties:files:` is strongly encouraged for proper Jekyll behavior.
+LiquiDoc will write an additional YAML file containing all of the Asciidoctor attributes, to be appended to this list when the build command is run.
+This captures attributes offered up in the action-level `data:` file and in the `attributes:` section of the build step.
 
-The *arguments* block is made up of key-value parameters that establish or override any _Jekyll_ config settings.
+The `arguments:` block is made up of key-value parameters that establish or override any _Jekyll_ config settings.
 
 [NOTE]
-The action-level parameter *source* is left blank in this example.
+The action-level parameter `source:` is left blank in this example.
 This setting _cannot_ be used to designate a Jekyll source path.
 If the above action had a second build step, such as a single output doc, the source would have relevance as the index file for that document.
 
 [[asciidoc-attributes]]
 ==== Setting AsciiDoc Attributes
-
-For basic `render` actions, the *source* file and other `.adoc` files determine most of the rest of the content source files (if any) using AsciiDoc includes.
+// tag::setting-asciidoc-attributes[]
+For basic `render` actions, the `source:` file and other `.adoc` files determine most of the rest of the content source files (if any) using AsciiDoc includes.
 But Asciidoctor renderings can be configured and manipulated by _attribute_ settings at other stages.
 Basically, we are trying to maximize our readiness to ingest document data and build properties from a wide range of sources.
 This way inline substitutions can be made out of data living outside the source tree of any particular document, passed into the document build in the form of YAML data converted into -- you guessed it -- AsciiDoc _attributes_.
@@ -672,7 +699,7 @@ Therefore, an identical value defined explicitly in each subsequent space will o
 The order of substitution is as follows.
 
 . <<asciidoc-doc-inline,AsciiDoc document inline>>
-. <<document data file,document-data-file>>
+. <<document-data-file,document data file>>
 . <<per-build-properties-files,per-build properties files>>
 . <<per-build-liquidoc-config,per-build in LiquiDoc config>>
 . <<command-line-arguments,command-line arguments>>
@@ -704,7 +731,7 @@ basedir: _build
 my_custom_var: Some text, can include spaces and most punctuation
 ----
 +
-This file must be called out in your configuration using the top-level *data* setting.
+This file must be called out in your configuration using the top-level `data:` setting.
 +
 [source,yaml]
 .Example AsciiDoc data file setting for attributes ingest
@@ -735,7 +762,7 @@ For starters, LiquiDoc can extract attributes from still more data files at this
       files: _conf/jekyll.yml,_data/china.yml
 ----
 +
-The *properties* > *files* setting can take the form of a comma-delimited list or a YAML array, and it can filter to specific subdata (see <<#more-data,below>>).
+The `properties:files` setting can take the form of a comma-delimited list or a YAML array, and it can filter to specific subdata (see <<#more-data,below>>).
 These per-build properties files are meant to be document settings, so for static site renderings (e.g., Jekyll), these are meant to contain YAML files formatted for Jekyll configuration reads.
 
 [[per-build-liquidoc-config]]
@@ -831,6 +858,8 @@ In this case, the render action will load the `settings.attributes` block from t
 +
 In this last case, we're passing locale settings for a premium edition targeted to a Chinese audience.
 
+// end::setting-asciidoc-attributes[]
+
 ==== Render Build Settings Overview
 
 Certain AsciiDoc/Asciidoctor settings are determinant enough that they can be set using parameters in the build config.
@@ -846,12 +875,12 @@ Static site generation renders, however, target a directory set in the SSG's con
 
 backend::
 The backend determines the rendering context.
-When building single-file output, the backend is typically determined from the *output* filename and/or the *doctype*.
+When building single-file output, the backend is typically determined from the `output:` filename and/or the `doctype:`.
 Some renderers, such as Jekyll, require specific backend designations (`jekyll`).
 Valid options are `html5`, `pdf`, `jekyll`, with more to come.
 
 doctype::
-Overrides *doctype* attribute.
+Overrides Asciidoctor *doctype* attribute.
 Valid values are:
 
 `book`:::
@@ -874,11 +903,11 @@ Designate one or more nested variables alongside ingested data in parse actions.
 
 properties::
 Designates a file or files for settings and additional explicit configuration at the build level for render actions.
-See <<per-build-properties-files>>.
+// end::render-operations[]
 
 === Deploy Operations
 
-Mainstream deployment platforms are probebly better suited to tying all your operations together, but we plan to bake a few common operations in to help you get started.
+Mainstream deployment platforms are probably better suited to tying all your operations together, but we plan to bake a few common operations in to help you get started.
 For true build-and-deployment control, consider build tools such as Make, Rake, and Gradle, or deployment tools like Travis CI, CircleCI, and Jenkins.
 
 ==== Jekyll Serve
@@ -886,7 +915,7 @@ For true build-and-deployment control, consider build tools such as Make, Rake, 
 For testing purposes, however, spinning up a local webserver with the same stroke that you build a site is pretty rewarding and time saving, so we'll start there.
 
 For now, this functionality is limited to adding a `--deploy` flag to your `liquidoc` command.
-This will attempt to serve files from the *destination* set for the associated Jekyll build.
+This will attempt to serve files from the `destination:` set for the associated Jekyll build.
 
 [WARNING]
 Deployment of Jekyll sites is both limited and untested under nonstandard conditions.
@@ -894,7 +923,7 @@ Deployment of Jekyll sites is both limited and untested under nonstandard condit
 ==== Algolia Search Indexing for Jekyll
 
 If you're using Jekyll to build sites, LiquiDoc makes indexing your files with the Algolia cloud search service a matter of configuration.
-The heavy lifting is performed by the jekyll-algolia plugin, but LiquiDoc can handle indexing even a complex site by using the same configuration that built your HTML content (which is what Algolia actually indexes).
+The heavy lifting is performed by the link:https://community.algolia.com/jekyll-algolia/[jekyll-algolia plugin], but LiquiDoc can handle indexing even a complex site by using the same configuration that built your HTML content (which is what Algolia actually indexes).
 
 [NOTE]
 You will need a free community (or premium) link:https://www.algolia.com/users/sign_up/hacker[Algolia account] to take advantage of Algolia's indexing service and REST API.
@@ -939,9 +968,10 @@ algolia:
 +
 The `index:` parameter is for the name of the index you are pushing to.
 (An Algolia “app” can have multiple “indices”.)
-If you have
+This entry _configures_ but does not _trigger_ an indexing operation.
 
-Now you can call your same LiquiDoc build command with the `--search-index-push` or `--search-index-dry` flags along with the `--search-api-key='your-admin-api-key-here'` argument in order to invoke the indexing operation.
+Indexing is invoked by command-line flags.
+Add `--search-index-push` or `--search-index-dry` along with the `--search-api-key='your-admin-api-key-here'` argument in order to invoke the indexing operation.
 The `--search-index-dry` flag merely tests content packaging, whereas `--search-index-push` connects to the Algolia REST API and attempt to push your content for indexing and storage.
 
 .Example Jekyll Algolia deployment
@@ -957,42 +987,24 @@ To add modern site search for your users, add link:https://community.algolia.com
 
 == Configuring a LiquiDoc Build
 
-In order to seriously explore and instruct this tool's ability to single-source a product's entire docs-integrated codebase, I have set out on a project for LiquiDoc to eat its own proverbial dog food.
-That is, I'm using LiquiDoc to document LiquiDoc in a separate repository -- one which treats the LiquiDoc gem repository (_this_ repo) as a Git submodule.
-That is, for purposes of coding, _all_ of the *liquidoc-gem* repo's code is accesible by way of an alias path, `products/liquidoc-gem`, from the base of the *liquidoc-docs* project.
+Like any software or documentation build tool, routine configuration is everything.
+Everything needs to be just so in a build.
+Order matters, and resources must be used wisely.
 
-[NOTE]
-The <<config-settings-matrix,*Config Settings Matrix*>> has moved to the <<reference,Reference Section>>.
+Rather than discuss build strategies broadly here, I have opted to move all my recommendations to the LiquiDoc Content Management Framework.
+link:https://github.com/DocOps/liquidoc-cmf[LiquiDoc CMF's bootstrap repository] has more, but the link:https://www.ajyl.org/liquidoc-cmf-guides[LiquiDoc CMF Guides] are the real authority.
+For now, look there for LDCMF-specific as well as broader strategic build insights.
 
-=== Gem Repo as Submodule
-
-I am on record as prefering to _keep docs source in the same codebase as that of the product they reference_.
-I've used some version of that statement in almost everything I write on the matter.
-Yet there are plenty of reasons I can think of that strongly favor the product-as-submodule approach.
-I will explore other cases in _Codewriting_, but my reason in the case of LiquiDoc and its own docs is simply to avoid confusion between the utility and the docs.
-Call it ironic, but other than this README, you won't find LiquiDoc's documentation source inside its product repo.
-
-But you will sort of find the product repo inside the docs repo, where the former's source can be used to inform content and build configurations alike.
-My intention is to establish a single source of truth among the two repos.
-
-I'll leave it to the link:https://github.com/DocOps/ldcmf-guides[LDCMF Guides README] to take it from here.
-That's where you'll find a more detailed project overview.
-
-On a final note, this means I will begin moving content from this README (where it sits like a static blob) into the highly dynamic LDCMF project.
-Other content will simply be +++include::[]+++ed into the project via that smuggling tunnel of a submodule.
-
-[[self-documenting-configuration]]
+[[self-doc-config]]
 === Self-Documenting Configuration
 
-An unscheduled feature started to make a lot of sense as I built the LiquiDoc project.
 For non-geniuses like myself, it can be really helpful to have a plain-English accounting of what is happening during a build procedure.
-I don't know if any other build utilities have a facility like this, but I added it with minimal effort (after getting over some abstract challenges I'll talk about elsewhere).
+During builds, LiquiDoc creates a secondary log as it churns through a configuration.
 
-I added some code to this gem that creates a secondary log as a LiquiDoc build iterates through a configuration file.
-If you add no new fields to your build config's YAML file, this secondary logger will still generate a plain-language description of the steps it is taking.
-By default these are written to a file stored under your build directory (`_build/pre/config-explainer.adoc` unless otherwise established).
-This file can be included into the build.
+If you add no documentation fields to your build config's YAML file, this secondary logger will still generate a plain-language description of the steps it is taking.
+But step can be enhanced with customized comments, as well, to pass along the reasoning behind any step.
 
+By default these are written “config explainers” to a file stored under your build directory (`_build/pre/config-explainer.adoc` unless otherwise established).
 Alternatively, the log will print to screen (console) during a configured LiquiDoc build procedure.
 Simply add the `--explicit` flag to your command.
 
@@ -1003,7 +1015,7 @@ bundle exec liquidoc -c _configs/build-docs.yml --explicit
 ----
 
 This feature will explain which sources are used to produce what output, but it won't say why.
-LiquiDoc administrator's can state the purpuse of each action step and each build sub-step.
+LiquiDoc administrators can state the purpose of each action step and each build sub-step.
 There are two ways to intervene with the automated log message.
 
 message::
@@ -1012,7 +1024,7 @@ The contents of this parameter will appear _instead of_ the automated message.
 
 reason::
 The reason will be integrated with the automated message (it's moot with a custom message as described above).
-Usually it will be appended as a comma-demarcated phrase at the end of the automated statement or in a sensible place in the middle.
+Usually it will be appended as a comma-demarcated phrase at the end of the automated statement or in a sensible place in the middle, depending on the structure of the automated message.
 
 .Example from LDCMF Guides `_configs/build-docs.yml`
 [source,yaml]
@@ -1042,25 +1054,21 @@ You may also use bullets (`*`), add styling directives or other markers, etc.
 .. Builds the stories index file used to give order to the PDF index file's inclusion of topic files (`_build/includes/_built_page-meta.adoc`)
 ====
 
-Let me know if you find this “configuration explainer” feature useful.
-There are definitely some enhancements I could add to it, but I'm calling it a minimum-viable product for now.
+This config explainer feature is mainly intended to feed into documentation _about_ your primary docs build.
+The AsciiDoc-formatted explainers can be included anywhere in a document about your docs infrastructure.
 
 [[dynamic-config]]
 === Dynamic LiquiDoc Build Configurations
-
-As long as we're calling Liquid to manipulate files with templates in our parse operations, we might as well use it to parse our config files themselves.
+// tag::dynamic-config[]
+As long as we are invoking Liquid to manipulate files with templates in our parse operations, we had might as well use it to parse our config files themselves.
 This is an _advanced procedure_ for injecting programmatic functionality into your builds.
-If you're comfortable with Liquid templating, you are ready to learn dynamic configuration.
+If you are comfortable with Liquid templating and basic LiquiDoc build config structure, you are ready to learn dynamic configuration.
 
 As of LiquiDoc 0.9.0, config files can be parsed (preprocessed) at the top of a build.
-That is, your config files can contain variables, conditionals, and iterative loops -- any <<liquid-tags-supported,Liquid tags supported by LiquiDoc>>.
+That is, your config files can contain variables, conditionals, and iterative loops -- any Liquid tags and filters supported by LiquiDoc.
 
-All you have to do is (1) add Liquid tags to your YAML configuration file and (2) either (a) pass at least one _config variable_ to it when running your `liquidoc` command or (b) pass it the `--parseconfig` flag.
-
-Let's explore that second requirement.
+All you have to do is (1) add Liquid tags to your YAML configuration file.
 If the Liquid markup in your config file expects variables, pass those variables on the `liquidoc` CLI using `--var key=value`.
-Otherwise, if you are not passing variables to your config, instruct LiquiDoc to parse the config file using the `--parseconfig` CLI flag.
-For example, this might be the case if your config merely contains some simple looping functionality to process lots of files.
 
 [[config-variables]]
 ==== Using Config Variables
@@ -1188,78 +1196,41 @@ For instance,
 
 With a build config like this, optionally invoking `--var recipe=nopdf`, for instance, will suppress the PDF substep during the build routine.
 
-==== Generating Starter Files with Dynamic Configs
+==== Liquid Loops in Configs
 
-The ability to programmatically design config files makes LiquiDoc far more powerful as a UI for _content management_.
-The following example shows how thinking outside the box lets you use the very same tool with which you build your production docs, this time to generate stub files for your LiquiDoc CMF application.
+Aside from implementing conditional elements in your configs, dynamism also introduces looping.
+Repetitive procedures that take up lots of vertical space to repeat sequentially with largely the same specifics can be difficult to manage.
+If you're building lots of parallel documents from the same source with minimal differences in each configuration action or build step, you may find yourself wishing you could write once and execute five times.
 
-Once you're comfortable with the concept of <<dynamic-config,dynamic LiquiDoc configs>>, check out this example, which you can implement right now in your LDCMF instance.
+With Liquid's _for_ loops, you can do just that.
+Review this code and imagine how much vertical space is saved.
 
-.Example liquidoc execution with a dynamic config file
-[source,shell]
-----
-bundle exec liquidoc -c _configs/init_topic.yml --var slug=some_c_slug-string --var title='Some Topic Title for Publication'
-----
-
-The example above commands an extraordinary LiquiDoc build routine.
-The configuration file, `init_topic.yml`, creates topic-file stubs and schema-file entries in fulfillment of LiquiDoc CMF conventions.
-
-.Example configuration file for topic-file stub generation
+.Example space-saving 'for' loop in Liquid
 [source,yaml]
 ----
-- action: parse
+{% assign products = "one,two,three,four,five" | split: "," %}
+{% assign langs = "en,es" %}
+- stage: parse-strings
+  action: parse
+  data: data/strings.yml
   builds:
-    - template: _templates/liquid/init_topic.asciidoc
-      output: content/topics/{{ vars.slug }}.adoc
+{% for prod in portals %}{% for lang in langs %}
+    - output: strings-{{prod}}-{{lang}}.yml
+      template: string-processing.yaml
       variables:
-        slug: {{ vars.slug }}
-        title: {{ vars.title }}
-    - template: _templates/liquid/init_topic_schema.yaml
-      output: stdout
-      variables:
-        slug: {{ vars.slug }}
-        title: {{ vars.title }}
+        portal: {{prod}}
+        lang: {{lang}}
+{% endfor %}
 ----
 
-As you can see, since this file has Liquid variables embedded in it, we must pass those variables during CLI execution in order for the build to work at all.
-This config file is parsed just like any standard parse action, though it uses the `--var` option to ingest environment variables, scoped as `vars.` in the template (remember, in this case _the config file itself is the template_).
-Parsing the configuration will essentially be the first act of the configured build routine, which will then run the parsed file, step by step.
+This code saves the space and maintenance of five `-output:` blocks.
 
-.Example _parsed_ config file for topic-file stub generation
-[source,yaml]
-----
-- action: parse
-  builds:
-    - template: _templates/liquid/init_topic.asciidoc
-      output: content/topics/some_c_slug-string.adoc
-      variables:
-        slug: some_c_slug-string
-        title: Some Topic Title for Publication
-    - template: _templates/liquid/init_topic_schema.yaml
-      output: stdout
-      variables:
-        slug: some_c_slug-string
-        title: Some Topic Title for Publication
-----
+[TIP]
+In Liquid, loops can only iterate through arrays.
+Comma-delimited lists can be converted to arrays using the *split* filter to divide its contents into items.
+The `| split: ","` notation here tells Liquid we wish to apply this filter so the variable `portals` can become an array.
 
-Now that we have expanded our `slug` and `title` values into a clean final config, we see that we are generating a file (`some_c_slug-string.adoc`) from one template (`init_topic.asciidoc`).
-We are also generating some screen output (`stdout`) from another template (`init_topic_schema.yaml`).
-The first action generates the LDCMF-style topic file, including its filename and first line, which includes header information generated from the schema.
-
-.Example header include in generated stub
-[source,asciidoc]
-----
-include::{topic_page_meta}[tags="some_c_slug-string"]
-----
-
-Speaking of getting topic metadata from a schema file; first we need to set it.
-In the second build step, we print our new topic's minimal schema entry information for author convenience.
-This can be copied and pasted into your LDCMF schema.
-
-[NOTE]
-*Configuration recipes* are a related feature which is link:https://github.com/DocOps/liquidoc-gem/issues/33[still slated].
-
-// end::usage[]
+// end::dynamic-config[]
 
 == Reference
 
@@ -1283,7 +1254,7 @@ Here is a table of all the established configuration settings, as they pertain t
 | Render
 | Deploy
 
-5+s| Main Per-step Settings
+5+s| Main Per-stage Settings
 
 s| action
 | Required
@@ -1396,14 +1367,17 @@ Except I kind of disagree.
 To me, it's one of the most elegant ideas I've ever worked on, and I actually adore it.
 
 Maybe it's due to my love of flat files.
-The simplicity of _anything in / anything out_ for flat files is such a holy grail in my mind.
-I am a huge fan of link:http://pandoc.org/[Pandoc], which has saved me countless hours of struggle.
-I totally dig markup languages and dynamic template engines, both of which I've been using to build cool shit for almost 20 years.
+The simplicity of _anything in / anything out_ for plaintext files is such a holy grail in my mind.
+I am a huge fan of the universal converter link:http://pandoc.org/[Pandoc], which has saved me countless hours of struggle.
 
-You don't have to love it to use it, or even to contribute.
+
+I totally dig _markup languages_ and _dynamic template engines_, both of which I've been using to build cool shit for about 20 years.
+These form the direct sublayers of everything done with textual content in computing, and I want to help others play in the sandbox of dynamic markup.
+
+You don't have to love LiquiDoc to use it, or even to contribute.
 But if you get what I'm trying to do, give a holler.
 
-The reason I'm developing LiquiDoc is to most flexibly handle common single-sourcing challenges posed by a divergence in tools.
+The reason I'm developing LiquiDoc is to most flexibly handle common single-sourcing challenges posed by divergent output needs.
 I intend to experiment with other toolchains, datasource types, and template engines, but the point of this utility is to pull together great technologies to solve tough, recurring problems.
 // end::meta[]
 
@@ -1423,7 +1397,7 @@ I guess by that I mean, I'm resisting over-abstracting the source -- I must be t
 
 I am very eager to collaborate, and I actually have extensive experience with collective authorship and product design, but I'm not a very social _programmer_.
 If you want to contribute to this tool, please get in touch.
-A *merge request* is a great way to reach out.
+A *pull request* is a great way to reach out.
 // end::contributing[]
 
 === Licensing

--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,7 @@
 :xref_source-markup-liquid-basics: liquid-templating
 :xref_build-config-dynamic: dynamic-config
 :xref_build-config-file-local: self-doc-config
-:toc: preamble
+:toc:
 
 // tag::overview[]
 LiquiDoc is a documentation build utility for true single-sourcing of technical content and data.

--- a/README.adoc
+++ b/README.adoc
@@ -14,13 +14,14 @@
 :xref_source-markup-liquid-basics: liquid-templating
 :xref_build-config-dynamic: dynamic-config
 :xref_build-config-file-local: self-doc-config
-
 :toc: macro
 
 // tag::overview[]
 LiquiDoc is a documentation build utility for true single-sourcing of technical content and data.
 It is especially suited for documentation projects with various required output formats from complex, single-sourced codebases, but it is intended for any project with complex, versioned input data for use in docs, user interfaces, and even back-end code.
 The highly configurable command-line utility (and Ruby gem) engages template engines to parse complex data into rich text output, from *blogs* to *books* to *knowledge bases* to *slide presentations*.
+
+toc::[]
 
 Sources can be flat files in formats such as *XML* (eXtensible Markup Language), *JSON* (JavaScript Object Notation), *CSV* (comma-separated values), and our preferred human-editable format: *YAML* (acronym link:https://en.wikipedia.org/wiki/YAML#History_and_name[in dispute]).
 LiquiDoc also accepts *regular expressions* to parse unconventionally formatted files.
@@ -29,8 +30,6 @@ LiquiDoc relies heavily on the Asciidoctor rendering engine, which produces HTML
 
 Output can be pretty much any flat file, with automatic data conversions to JSON and YAML, as well as rich-text/multimedia formats like HTML, PDF, slide decks, and more.
 // end::overview[]
-
-toc::[]
 
 // tag::rocana-note[]
 [NOTE]


### PR DESCRIPTION
Adds some dynamic features, mainly so Readme content can now be used to single source additional codebases, such as the [LiquiDoc CMF Guides repo](https://github.com/DocOps/liquidoc-cmf-guides).

Also clarifies and tidies the documentation. Some strategy-oriented content (e.g., "Gem Repo as Submodule") are moved to LDCMF Guides. The goal is to keep this readme to direct applications of LiquiDoc, the utility.