### PR TITLE
Fix options bug; add ability to skip missing migrate sources

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -555,13 +555,16 @@ In addition to designating `action: migrate`, migrate operations require just a 
 .Example config -- Instructing file copies with 'migrate' action
 ----
 - action: migrate
+  source: index.adoc
+  target: _build/
+- action: migrate
   source: assets/images
   target: _build/img
   options:
     inclusive: false
 - action: migrate
-  source: index-map.adoc
-  target: _build/index-map.adoc
+  source: tmp/{{imported_file}}.adoc
+  target: _build/{{portal_path}}/{{imported_file}}.adoc
   options:
     missing: warn
 ----
@@ -573,8 +576,9 @@ When inclusive is `false`, they copy to `target/`.
 
 Individual files must be listed in individual steps, one per step, as in the second step above.
 
-In case of a missing source directory or file to be migrated, the default behavior is the exit the operation (`missing: raise`).
-This can be overridden by setting the option `missing: warn`.
+In case of a missing source directory or file to be migrated, the default behavior is to exit the build operation (`missing: exit`).
+This can be overridden and the migrate action skipped when the source is missing.
+Setting the option `missing: warn` logs a warning to console, and `missing: skip` will only print a warning under `--verbose` operations.
 
 // end::migrate-operations[]
 

--- a/README.adoc
+++ b/README.adoc
@@ -562,6 +562,8 @@ In addition to designating `action: migrate`, migrate operations require just a 
 - action: migrate
   source: index-map.adoc
   target: _build/index-map.adoc
+  options:
+    missing: warn
 ----
 
 The first action step above copies all the files and folders in `assets/images` and adds them to `_build/img`.
@@ -570,6 +572,10 @@ When both the source and target paths are directories and inclusive is `true`, t
 When inclusive is `false`, they copy to `target/`.
 
 Individual files must be listed in individual steps, one per step, as in the second step above.
+
+In case of a missing source directory or file to be migrated, the default behavior is the exit the operation (`missing: raise`).
+This can be overridden by setting the option `missing: warn`.
+
 // end::migrate-operations[]
 
 === Render Operations

--- a/lib/liquidoc.rb
+++ b/lib/liquidoc.rb
@@ -10,7 +10,6 @@ require 'csv'
 require 'crack/xml'
 require 'fileutils'
 require 'jekyll'
-require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
 
 # ===
 # Table of Contents

--- a/lib/liquidoc/version.rb
+++ b/lib/liquidoc/version.rb
@@ -1,3 +1,3 @@
 module Liquidoc
-  VERSION = "0.9.4"
+  VERSION = "0.9.5"
 end


### PR DESCRIPTION
The `options:` setting for `migrate` actions was reading an erroneous truthiness to test for the existence of a setting.
Fixed this so opt settings other than `inclusive: false` actually work.

Added the ability to set an option `missing:` with either `warn` or `raise` as values.
- `missing: warn`: the operation skips the migrate step and logs a warning to console.
- `missing: skip`: the operation skips, only warning under `--verbose`.
- `missing: exit` (default, backward compatible): the operation throws an error and exits.

Added example and explanation for new `missing:` setting to README and improved the illustrative capacity of the examples.

Thanks for help from Hector Palacios (@hpalacio).