### PR TITLE
migrate: add 'skip' as a value for 'missing' option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -574,7 +574,7 @@ When inclusive is `false`, they copy to `target/`.
 Individual files must be listed in individual steps, one per step, as in the second step above.
 
 In case of a missing source directory or file to be migrated, the default behavior is the exit the operation (`missing: raise`).
-This can be overridden by setting the option `missing: warn`.
+This can be overridden by setting the option `missing: warn`, to get a warning, or `missing: skip` to not even try the copy operation if the source does not exist.
 
 // end::migrate-operations[]
 

--- a/lib/liquidoc.rb
+++ b/lib/liquidoc.rb
@@ -796,6 +796,9 @@ def copy_assets src, dest, inclusive=true, missing='exit'
   unless File.file?(src)
     unless inclusive then src = src + "/." end
   end
+  if !File.file?(src) && !File.directory?(src)
+    if missing == "skip" then return end
+  end
   @logger.debug "Copying #{src} to #{dest}"
   begin
     FileUtils.mkdir_p(dest) unless File.directory?(dest)


### PR DESCRIPTION
When 'skip' is specified, the copy operation is not even tried
if the source does not exist.

Signed-off-by: Hector Palacios <scarzia00@hotmail.com>