### PR TITLE
Enable multi-file ingest for parse operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 Gemfile.lock
 pkg
 *.gem
-docs/index.html
-docs/liquidoc-manual.html
+*.html
+*.pdf

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -37,26 +37,34 @@ include::../README.adoc[tags="installation"]
 
 :leveloffset: +1
 
+[[intro]]
 include::topics/intro.adoc[]
 
+[[parsing-basic]]
 include::topics/parsing_basic.adoc[]
 
+[[config-basic]]
 include::topics/config_basic.adoc[]
 
+[[action-parse]]
 include::topics/action_parse.adoc[]
 
+[[action-migrate]]
 include::topics/action_migrate.adoc[]
 
+[[action-render]]
 include::topics/action_render.adoc[]
 
+[[action-deploy]]
 include::topics/action_deploy.adoc[]
 
+[[action-execute]]
 include::topics/action_execute.adoc[]
 
-include::topics/action_execute.adoc[]
-
+[[config-full]]
 include::topics/config_full.adoc[]
 
+[[reference]]
 include::topics/reference.adoc[]
 
 :leveloffset: -1

--- a/docs/topics/action_parse.adoc
+++ b/docs/topics/action_parse.adoc
@@ -8,13 +8,24 @@ Valid data sources come in a few different types.
 There are the built-in data types (YAML, JSON, XML, CSV) vs free-form type (files processed using regular expressions, designated by the `regex` data type).
 There is also a divide between simple one-record-per-line data types (CSV and regex), which produce one set of parameters for every line in the source file, versus nested data types that can reflect far more complex structures.
 
+[[native-nested-data]]
 === Native Nested Data (YAML, JSON, XML)
 
 The native nested formats are actually the most straightforward.
 So long as your filename has a conventional extension, you can just pass a file path for this setting.
 That is, if your file ends in `.yml`, `.json`, or `.xml`, and your data is properly formatted, LiquiDoc will parse it appropriately.
 
-For standard-format files that have non-standard file extensions (for example, `.js` rather than `.json` for a JSON-formatted file), you must declare a type explicitly.
+[source,yaml]
+.Example config -- conventional, single-source parsing action
+----
+- action: parse
+  data: _data/source_data_file.json
+  builds:
+    - template: _templates/liquid_template.html
+      output: _output/output_file.html
+----
+
+For standard-format files that have nonstandard file extensions (for example, `.js` rather than `.json` for a JSON-formatted file), you must declare a type explicitly.
 
 [source,yaml]
 .Example config -- Instructing correct type for mislabeled JSON file
@@ -30,6 +41,7 @@ For standard-format files that have non-standard file extensions (for example, `
 
 Once LiquiDoc knows the right file type, it will parse the file into a Ruby object for further processing.
 
+[[csv-data]]
 === CSV Data
 
 Data ingested from CSV files will use the first row as key names for columnar data in the subsequent rows, as shown below.
@@ -59,7 +71,8 @@ data[1].default #=> 300
 data[1].required #=> false
 ----
 
-=== Unstructured Data
+[[unstructured-data]]
+=== Unstructured Data Ingest
 
 Unstructured data files can be ingested as well, as long as records are delineated by lines (as with CSV) _and_ each line meets a consistent pattern we can “scrape” for data to organize.
 This method generates arrays of structures similarly to the CSV approach.
@@ -154,7 +167,8 @@ Your pattern must contain at least one group, denoted with unescaped `(` and `)`
 This will be expressed during logging, and eventually it will enable us to suppress or reorder steps by name (see link:https://github.com/DocOps/liquidoc-gem/issues/33[Issue #33]).
 ****
 
-== Default Output Formats
+[[default-output-conversions]]
+== Default Output Formats (Direct Conversions)
 
 LiquiDoc can directly convert any supported semi-structured data input format to either YAML or JSON output.
 Simply provide no template parameter, and make sure the output file has a proper extension (`.yml` or `.json`).
@@ -164,7 +178,8 @@ Simply provide no template parameter, and make sure the output file has a proper
 ----
 - action: parse
   data: _data/testdata.xml
-  output: _build/frontend/testdata.json
+  builds:
+    - output: _build/frontend/testdata.json
 ----
 
 [NOTE]
@@ -183,7 +198,9 @@ endif::[]
 
 == Passing Additional Variables
 
-In addition to data files, parse operations accept fixed variables and environment variables.
+In addition to (or instead of) data files, parse operations accept fixed variables and environment variables.
+
+=== Fixed/Config Variables
 
 *Fixed variables* are defined using a _per-build_ structure called `variables:` in the config file.
 Each build operation can accept a distinct set of variables.
@@ -226,6 +243,99 @@ Inside that template, we might find a block of Liquid code hiding some navigatio
 
 This portion of the example config presses two versions of the Liquid template `side-nav.html` into two different nav menus, either to be served on two parallel sites or one site with the ability to select front-end elements depending on user status.
 In this example, only the menu shown to premium users will contain the billing link; basic users will see an upgrade prompt.
+
+=== Environment/Execution Variables
+
+The other way to pass variables into builds is during the execution of the LiquiDoc gem.
+When performing a configured build, pass config variables to a *dynamic configuration* file in order to trigger different settings or routines, as documented in <<dynamic-config>>.
+
+[[passing-vars-default-output]]
+=== Passing Variables to Direct Conversions
+
+Data being converted directly to a default output format is also eligible for injection of variables from the command line or config file.
+
+.Example command-line LiquiDoc conversion with variables added
+[source,shell]
+bundle exec liquidoc -d data/original.xml -o _build/converted.json -v env=staging -v lang=en-us
+
+[NOTE]
+The previous example command is functionally identical to the following configuration step.
+
+.Example configured LiquiDoc conversion with variables added
+[source,yaml]
+----
+- action: parse
+  data: data/original.xml
+  builds:
+    - output: _build/converted.json
+      variables:
+        env: staging
+        lang: en-us
+----
+
+If `original.xml` contains one key-value pair (`<test>true</test>`), the resulting JSON will situate additional variables alongside it.
+
+.Example direct-conversion output (“prettified” for docs)
+[source,json]
+----
+{
+  "test": true,
+  "env": "staging",
+  "lang": "en-us"
+}
+----
+
+[[multi-file-ingest]]
+== Multiple File Ingest
+
+Parse actions can ingest an indefinite number of data sources, with some restrictions.
+
+The parse action's `data:` parameter can accept an array of paths to any supported semi-structured data format, given the following standard file extensions (`.csv`, `.yml`, `.json`, `.xml`).
+Any other file, whether <<unstructured-data,nonstandard format>> or <<native-nested-data,nonstandard file extension>>, must first be converted to a standard format.
+
+[source,yaml]
+.Example config -- Multi datasource ingest
+----
+- action: parse
+  data:
+    - lib/strings/common-en.json
+    - data/app-strings.yml
+    - lang/settings.xml
+  builds:
+    - template: _templates/env-config.liquid.yaml
+      output: target/env-config-lang.yml
+      variables:
+        language:
+          short: en
+          full: English
+    - template: all-strings.liquid.json
+      output: all-strings.json
+----
+
+In this example, we imagine generating a couple of files useful to different parts of a documentation app, including common strings and language settings.
+In each Liquid template, we have access to several data objects.
+
+The `vars.` scope carries anything passed as `variables:` in the build step. For example, `{{vars.language.full}}` would resolve to `English` in this example build.
+
+For the ingested files, a scope is named after the source filename, minus its extension.
+In the above example, we could access variables from `common-en.json` as `{{common-en.keyname}}`, and so forth.
+
+[WARNING]
+Base filenames of files ingested in the same parse action must be distinct.
+
+LiquiDoc's multi-file datasource ingest works very similarly to Jekyll's templating, where always-available data objects are derived from files in the data directory.
+The key difference is that files must be explicitly listed for each parse action in order for their data to be available.
+
+This functionality also resembles the multi-file attributes ingest in render operations, using the same parameter, `data:`.
+But whereas attribute-file ingest accepts a <<more-attributes-data,sub-data block indicator>>, this feature is redundant and thus not available in parse operations.
+Entire files are ingested and passed to the designated templates during parsing.
+
+=== Converting Multiple Data Files to a Default Format
+
+Just as LiquiDoc will objectify a series of data files for a templated conversion, it can also merge numerous files into a unified data object and output it as a single JSON or YAML file.
+The resulting data file will carry an object named for each file, as with standard multi-file ingest, and any passed variables are situated at the root.
+
+See <<default-output-conversions>> and <<passing-vars-default-output>>.
 
 == Output
 

--- a/docs/topics/action_render.adoc
+++ b/docs/topics/action_render.adoc
@@ -130,7 +130,7 @@ The order of substitution is as follows.
 . <<per-build-liquidoc-config,per-build in LiquiDoc config>>
 . <<command-line-arguments,command-line arguments>>
 
-After that, we'll demonstrate even <<more-data,more ways to ingest datasets>>.
+After that, we'll demonstrate even <<more-attributes-data,more ways to ingest datasets>>.
 
 [[asciidoc-doc-inline]]
 AsciiDoc document inline::
@@ -244,7 +244,7 @@ You may pass as many attributes as you like this way, up to the capacity of your
 bundle exec liquidoc -c _configs/my_book.yml -a edition='Very Special NSFW'
 ----
 
-[[more-data]]
+[[more-attributes-data]]
 == More ways to Ingest Attributes Data
 
 multiple attribute files::

--- a/docs/topics/templating_liquid.adoc
+++ b/docs/topics/templating_liquid.adoc
@@ -4,8 +4,63 @@ Shopify's open-source link:https://help.shopify.com/themes/liquid/basics[*Liquid
 For instance, a data structure of glossary terms and definitions that needs to be looped over and pressed into a more publish-ready markup, such as Markdown, AsciiDoc, reStructuredText, LaTeX, or HTML.
 
 Any valid Liquid-formatted template is accepted, in the form of a text file with any extension.
-For data sourced in CSV format or extracted through regex source parsing, all data is passed to the Liquid template parser as an array called `data:`, containing one or more rows to be iterated through.
-Data sourced in YAML, XML, or JSON may be passed as complex structures with custom names determined in the file contents.
+
+== Data Objects
+
+Ingested data objects can take the form of serialized arrays or non-serialized structures.
+
+For data sourced in <<csv_data,CSV format>> or extracted through regex source parsing, all data is passed to the Liquid template parser as an *array* object called `data`, containing one or more “rows” of data.
+This extends to YAML and JSON data formed as serialized at their root.
+
+.Example serialized YAML array
+[source,yaml]
+----
+- Item1
+- Item2
+----
+
+.Example serialized JSON array
+[source,json]
+----
+[
+	"Item1",
+	"Item2"
+]
+----
+
+Once ingested, such data can be expressed using the `data.` scope.
+
+[source,liquid]
+----
+{% for i in data %}
+* {{i}}
+{% endfor %}
+----
+
+XML files typically contains arrays/collections nested in parent elements.
+
+[source,xml]
+----
+<items>
+  <item>Item1</item>
+  <item>Item2</item>
+</items>
+----
+
+For nested arrays of this type, the key name is that of the containing element.
+
+[source,liquid]
+----
+{% for i in items %}
+* {{i}}
+{% endfor %}
+----
+
+Data sourced as non-serialized structures in YAML, XML, or JSON may be similarly expressed, using their nested identifiers, with keys determined in the origin contents.
+
+Additional variables passed during gem execution may be expressed under the `vars.` scope (`{{vars.variable_key}}`) or at the root (`{{variable_key}}`, for <<action-parse#default-output-conversions,direct conversions>>).
+
+== Iteration
 
 Looping through known data formats is fairly straightforward.
 A _for_ loop iterates through your data, item by item.


### PR DESCRIPTION
* Enhances DataSrc object management
* Establishes DataFile and DataObj classes
* DataSrc interprets the data: parameter
* DataFile enforces an array of datasource files
* DataObj carries an uber-hash of objects to feed liquify
* Adds documentation for multi-file ingest
* Ignores docs output