### PR TITLE
Write distinct AsciiDoc and Jekyll argument files per build

### DIFF
--- a/lib/liquidoc/version.rb
+++ b/lib/liquidoc/version.rb
@@ -1,3 +1,3 @@
 module Liquidoc
-  VERSION = "0.12.0-rc3"
+  VERSION = "0.12.0-rc4"
 end

--- a/liquidoc.gemspec
+++ b/liquidoc.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{A highly configurable command-line tool for parsing data and content in common flat-file formats.}
   spec.description   = %q{LiquiDoc conveniently harnesses the power of Liquid templates, flat-file data formats such as YAML, JSON, XML, and CSV, as well as AsciiDoc markup and powerful Asciidoctor output capabilities -- all in a single command-line tool.}
-  spec.homepage      = "https://github.com/scalingdata/liquidoc"
+  spec.homepage      = "https://github.com/DocOps/liquidoc"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
Instead of overwriting args_opts.yml and _attributes.yml, write
numbered files and leave them behind in pre/ after each build
routine runs.